### PR TITLE
Update settings.json to disable autoupdate and popups

### DIFF
--- a/images/ansible/roles/code_server/templates/settings.json
+++ b/images/ansible/roles/code_server/templates/settings.json
@@ -15,6 +15,10 @@
     "git.autofetch": false,
     "editor.renderWhitespace": "all",
     "workbench.colorTheme": "Default Dark+",
+    "extensions.ignoreRecommendations": true,
+    "extensions.autoCheckUpdates": false,
+    "extensions.autoUpdate": false,
+    "yaml.extension.recommendations": false,
     "files.associations": {
         "*.yml": "ansible"
     }


### PR DESCRIPTION
Adds the settings.json changes for the lab. 

Removes pop up notifications for the Red Hat Telemetry extension and the YAML extension recommendations. 

Also turns off the auto-update and checking for updates settings. 